### PR TITLE
Added "setBash" method

### DIFF
--- a/src/SteveEdson/BitBar.php
+++ b/src/SteveEdson/BitBar.php
@@ -103,6 +103,15 @@ class BitBarLine {
         $this->terminal = (boolean) $boolean;
         return $this;
     }
+    
+    /**
+     * @param mixed text
+     * @return $this
+     */
+    public function setBash($text) {
+        $this->bash = $text;
+        return $this;
+    }
 
     /**
      * @param $boolean


### PR DESCRIPTION
Property bash was already set, however there was no way of setting it.  This PR adds a method that will set that property.
