### PR TITLE
Fix for wrong parameter "templateImage" + allow for changing both font face and font size independently

### DIFF
--- a/src/SteveEdson/BitBar.php
+++ b/src/SteveEdson/BitBar.php
@@ -219,13 +219,23 @@ class BitBarLine {
 
         $this->usedPipe = false;
 
-        if ($this->fontFace && $this->fontSize) {
+        if ($this->fontSize) {
             if (!$this->usedPipe) {
                 $string .= '|';
                 $this->usedPipe = true;
             }
 
-            $string .= ' ( \'size=' . $this->fontSize . '\' \'font=' . $this->fontFace . '\' )';
+            $string .= ' size=' . $this->fontSize;
+        }
+
+
+        if ($this->fontFace) {
+            if (!$this->usedPipe) {
+                $string .= '|';
+                $this->usedPipe = true;
+            }
+
+            $string .= ' font=' . $this->fontFace;
         }
 
         if ($this->colour) {

--- a/src/SteveEdson/BitBar.php
+++ b/src/SteveEdson/BitBar.php
@@ -312,7 +312,7 @@ class BitBarLine {
             }
 
             if($this->imageIsTemplate) {
-                $string .= ' imageTemplate="' . $this->image . '"';
+                $string .= ' templateImage="' . $this->image . '"';
             } else {
                 $string .= ' image="' . $this->image . '"';
             }


### PR DESCRIPTION
The param « imageTemplate » should actually be « templateImage ».

I haven’t replaced the variables names because that’s not important, even though they are backwards too.

Also, we were not able to change the font size OR the font face, it had to be both which is incorrect
